### PR TITLE
performance best practise

### DIFF
--- a/ff-suggest/suggestToSearch.js
+++ b/ff-suggest/suggestToSearch.js
@@ -18,7 +18,12 @@ document.addEventListener("ffReady", function () {
                      * used below for subscribing
                      */
                     return ["searchToSuggest"];
-                }
+                },
+                /**
+                 * if not needed within suggest, disabling asn and campaign make the search leaner / faster in the FACT-Finder backend
+                 */
+                useAsn: "false",
+                useCampaigns: "false",
             });
 
             /**


### PR DESCRIPTION
tested that with these flags set, `campaigns` and `groups` in _search result_ are `[]` and without not