### PR TITLE
ASN 3.0 migration

### DIFF
--- a/ff-asn/index.html
+++ b/ff-asn/index.html
@@ -36,6 +36,7 @@
 </header>
 <main>
     <ff-asn align="vertical" unresolved>
+
         <!--use this as a default template for all groups-->
         <ff-asn-group for-group="all" class="cursor">
             <ff-asn-group-element>
@@ -48,36 +49,31 @@
                     <span class="filterName">{{element.name}}</span>
                 </div>
             </ff-asn-group-element>
+
             <div slot="groupCaption" class="groupCaption">
                 {{group.name}}<span class="filterArrowDown">&nbsp;</span>
             </div>
 
-
             <div opened data-container="detailedLinks">
-                <!--we'll show all links which should be displayed immediately aside this element-->
+                <!--all links which should be displayed immediately appear inside this element-->
                 <div data-content="detailedLinks"></div>
+            </div>
 
-                <!--use this container for automatically showing the hiddenLinks container on tap-->
-                <div data-container="showMore">
-
-                    <!-- set the padding on an inner element so we don't suffer from height 0 + padding issues-->
-                    <span class="text">Show More</span>
-                </div>
-
-                <div class="marginBottom"></div>
+            <!--use this container for automatically showing the hiddenLinks container on tap-->
+            <div data-container="showMore">
+                <!-- set the padding on an inner element so we don't suffer from height 0 + padding issues-->
+                <span class="text">Show More</span>
             </div>
 
             <div data-container="hiddenLinks">
-                <!--we'll hide all links which should NOT be displayed immediately aside this element-->
+                <!--all links which should NOT be displayed immediately appear inside this element-->
                 <div data-content="hiddenLinks"></div>
+            </div>
 
-                <!--use this container for automatically hiding the hiddenLinks container on tap-->
-                <div data-container="showLess">
-
-                    <!-- set the padding on an inner element so we don't suffer from height 0 + padding issues-->
-                    <span class="text">Show Less</span>
-                </div>
-                <div class="marginBottom"></div>
+            <!--use this container for automatically hiding the hiddenLinks container on tap-->
+            <div data-container="showLess">
+                <!-- set the padding on an inner element so we don't suffer from height 0 + padding issues-->
+                <span class="text">Show Less</span>
             </div>
         </ff-asn-group>
 
@@ -96,7 +92,6 @@
             </div>
             <div opened data-container="detailedLinks">
                 <div data-content="detailedLinks"></div>
-                <div class="marginBottom"></div>
             </div>
         </ff-asn-group>
 

--- a/ff-asn/index.html
+++ b/ff-asn/index.html
@@ -11,7 +11,7 @@
     <script defer src="../bower_components/ff-web-components/dist/bundle.js"></script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="trousers"

--- a/ff-breadcrumb-trail/index.html
+++ b/ff-breadcrumb-trail/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!-- Configure the connection to the FF-Search backend and a default query-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="jacken"

--- a/ff-campaign-landing-page/index.html
+++ b/ff-campaign-landing-page/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"></ff-communication>
 

--- a/ff-campaign-product/index.html
+++ b/ff-campaign-product/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="../demo-styles.css">
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk">
 </ff-communication>

--- a/ff-campaign-pushed-products/index.html
+++ b/ff-campaign-pushed-products/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="sale"

--- a/ff-campaign-shopping-cart/index.html
+++ b/ff-campaign-shopping-cart/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="../demo-styles.css">
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"></ff-communication>
 

--- a/ff-campaign/index.html
+++ b/ff-campaign/index.html
@@ -36,7 +36,7 @@
 </head>
 <body>
 <!-- basic communication configuration -->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="jacket"

--- a/ff-carousel/index.html
+++ b/ff-carousel/index.html
@@ -104,7 +104,7 @@
     </style>
 </custom-style>
 
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   ignore-page="true"></ff-communication>

--- a/ff-compare/index.html
+++ b/ff-compare/index.html
@@ -40,7 +40,7 @@
     <script defer src="../bower_components/ff-web-components/dist/bundle.js"></script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="jacke"

--- a/ff-header-navigation/index.html
+++ b/ff-header-navigation/index.html
@@ -10,7 +10,7 @@
     <script defer src="../bower_components/ff-web-components/dist/bundle.js"></script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk">
 </ff-communication>

--- a/ff-navigation/horizontalNavigation.html
+++ b/ff-navigation/horizontalNavigation.html
@@ -45,7 +45,7 @@
     </style>
 </custom-style>
 
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   search-immediate="true">

--- a/ff-navigation/verticalNavigation.html
+++ b/ff-navigation/verticalNavigation.html
@@ -50,7 +50,7 @@
     </style>
 </custom-style>
 
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   search-immediate="true">

--- a/ff-onfocus-suggest/index.html
+++ b/ff-onfocus-suggest/index.html
@@ -45,7 +45,7 @@
     </custom-style>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk">
 </ff-communication>

--- a/ff-paging-dropdown/index.html
+++ b/ff-paging-dropdown/index.html
@@ -36,7 +36,7 @@
 </head>
 <body>
 <!-- basic connection configuration-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="trousers"

--- a/ff-paging/index.html
+++ b/ff-paging/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <!-- basic connection configuration-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="trousers"

--- a/ff-products-per-page/index.html
+++ b/ff-products-per-page/index.html
@@ -12,7 +12,7 @@
     <link rel="import" href="styles.html">
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="trousers"

--- a/ff-recommendation/index.html
+++ b/ff-recommendation/index.html
@@ -56,7 +56,7 @@
 </head>
 <body>
 <!-- basic communication configuration-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="trousers"

--- a/ff-record-list-3d/index.html
+++ b/ff-record-list-3d/index.html
@@ -76,7 +76,7 @@
 </head>
 <body>
 <!-- basic communication configuration-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="trousers"
                   channel="bergfreunde-co-uk"

--- a/ff-record-list/index.html
+++ b/ff-record-list/index.html
@@ -10,7 +10,7 @@
     <script defer src="../bower_components/ff-web-components/dist/bundle.js"></script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="bagpack"
                   channel="bergfreunde-co-uk"

--- a/ff-search-feedback/index.html
+++ b/ff-search-feedback/index.html
@@ -38,7 +38,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+    <ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                       version="7.2"
                       channel="bergfreunde-co-uk"
                       default-query="jacket"

--- a/ff-searchbox/index.html
+++ b/ff-searchbox/index.html
@@ -10,7 +10,7 @@
     <script defer src="../bower_components/ff-web-components/dist/bundle.js"></script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="bagpack"
                   channel="bergfreunde-co-uk"

--- a/ff-similar-products/index.html
+++ b/ff-similar-products/index.html
@@ -40,7 +40,7 @@
 </head>
 <body>
 <!-- basic communication configuration-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="trousers"
                   channel="bergfreunde-co-uk"

--- a/ff-single-word-search/index.html
+++ b/ff-single-word-search/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <!-- Configure the connection to the FF-Search backend and a default query-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="davidoff crocs purpur"

--- a/ff-sortbox/index.html
+++ b/ff-sortbox/index.html
@@ -18,7 +18,7 @@
     </script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   default-query="trousers"

--- a/ff-suggest-without-ff-searchbox/index.html
+++ b/ff-suggest-without-ff-searchbox/index.html
@@ -45,7 +45,7 @@
 <body>
 
 <!-- Configure the connection to the FF-Search backend and a default query-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk">
 </ff-communication>

--- a/ff-suggest_suggestToSearch/index.html
+++ b/ff-suggest_suggestToSearch/index.html
@@ -15,7 +15,7 @@
 <body>
 
 <!-- Configure the connection to the FF-Search backend and a default query-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="trou"
                   channel="bergfreunde-co-uk"

--- a/ff-suggest_suggestToSearch/suggest_search.html
+++ b/ff-suggest_suggestToSearch/suggest_search.html
@@ -17,7 +17,7 @@
 <body>
 <h1>Use the seach API for product suggestions</h1>
 <!-- Configure the connection to the FF-Search backend and a default query-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="trou"
                   use-url-parameter="false"

--- a/ff-tag-cloud/index.html
+++ b/ff-tag-cloud/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+    <ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                       version="7.2"
                       channel="bergfreunde-co-uk">
     </ff-communication>

--- a/ff-template/index.html
+++ b/ff-template/index.html
@@ -110,7 +110,7 @@
 
 <div class="example">
 
-    <ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+    <ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                       version="7.2"
                       default-query="tasche"
                       channel="bergfreunde-de"

--- a/redirect-demo/index_webc.html
+++ b/redirect-demo/index_webc.html
@@ -16,7 +16,7 @@
 </head>
 <body>
 <!-- basic connection configuration-->
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk">
 </ff-communication>

--- a/redirect-demo/search.html
+++ b/redirect-demo/search.html
@@ -13,7 +13,7 @@
 
 <h2>This Page is build  with the FACT-Finder Web Components </h2>
 
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   channel="bergfreunde-co-uk"
                   use-url-parameter="false"

--- a/two-ff-suggests/index.html
+++ b/two-ff-suggests/index.html
@@ -68,7 +68,7 @@
     </script>
 </head>
 <body>
-<ff-communication url="http://search-web-components.fact-finder.de/FACT-Finder-7.2"
+<ff-communication url="https://search-web-components.fact-finder.de/FACT-Finder-7.2"
                   version="7.2"
                   default-query="trousers"
                   channel="bergfreunde-co-uk"


### PR DESCRIPTION
Contains a few markup fixed to make `ff-asn` work in `3.0`.
Also includes an old commit setting all `ff-communication` urls to https.
http urls won't work.